### PR TITLE
Remove the trailing slash

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -1,3 +1,3 @@
 #!/usr/bin/env node
 
-process.stdout.write(require('./').join('\n'))
+process.stdout.write(require('.').join('\n'))

--- a/example.js
+++ b/example.js
@@ -1,4 +1,4 @@
-const names = require('./')
+const names = require('.')
 
 names.indexOf('superagent') > -1
 // => true


### PR DESCRIPTION
We can simply `require(".")` to require the current directory. :grin: 